### PR TITLE
pivoting(task7): Ghost-row visuals + click routing

### DIFF
--- a/app/src/components/TreeTable.svelte
+++ b/app/src/components/TreeTable.svelte
@@ -51,6 +51,7 @@
   import TableColumnMenu from "./TableColumnMenu.svelte";
   import AddColumnButton from "./AddColumnButton.svelte";
   import { recordTelemetry } from "$lib/WorkItemContext.svelte";
+  import { isRowDraggable, findPrimaryRow } from "$lib/ghostRouting";
 
   let {
     columns = $bindable(),
@@ -128,7 +129,18 @@
     let element = e.target as HTMLElement;
     let rowId = element.getAttribute("data-row-id");
 
-    if (rowId && e.dataTransfer !== null) {
+    if (!rowId) return;
+
+    // Defense-in-depth: even though `draggable` is bound to isRowDraggable
+    // and should already be false on ghost rows, suppress the drag start
+    // here too so a stale browser attribute can't initiate a drag.
+    const row = rows.find((r) => r.id === rowId);
+    if (row?.isGhost) {
+      e.preventDefault();
+      return;
+    }
+
+    if (e.dataTransfer !== null) {
       e.dataTransfer.dropEffect = "move";
       draggedRowId = rowId;
     }
@@ -185,9 +197,43 @@
   function getRowClass(row: MRow<T>) {
     if (row.id === draggedRowId) return "outline-1 bg-primary-500";
     if (row.id === currentDropRowId) return "outline-2 bg-secondary-500";
+    // Ghost rows are reflections of a primary occurrence elsewhere in the
+    // tree. Render them muted (italic + lower-contrast text) and suppress
+    // the hover background so they feel less interactive than real rows.
+    if (row.isGhost) return "italic text-surface-500-500";
     if (row.isModified) return "bg-secondary-300-700";
     if (row.modifiedDescendent) return "bg-secondary-50-950";
     return "hover:bg-surface-100-900";
+  }
+
+  // Handles a left-click on a row. For ghost rows it routes the click to the
+  // primary occurrence (scrolls it into view). For non-ghost rows it is a
+  // no-op — TreeTable has no row-selection concept of its own. Clicks that
+  // originated on an interactive child (button, link) are ignored so the
+  // expander/link handlers stay authoritative.
+  function handleRowClick(e: MouseEvent, row: MRow<T>) {
+    if (!row.isGhost) return;
+    const target = e.target as HTMLElement | null;
+    if (target?.closest("button, a")) return;
+
+    const primaryId = findPrimaryRow(rows, row.id)?.id;
+    if (!primaryId) {
+      console.debug(
+        `[TreeTable] ghost click on ${row.id}: no primary occurrence in view`,
+      );
+      return;
+    }
+
+    const element = document.querySelector<HTMLElement>(
+      `[data-row-id="${CSS.escape(primaryId)}"]`,
+    );
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "center" });
+    } else {
+      console.debug(
+        `[TreeTable] ghost click on ${row.id}: primary ${primaryId} not in DOM`,
+      );
+    }
   }
 
   let columnResize:
@@ -400,8 +446,9 @@
                 menuOpen ? "outline-2 bg-primary-500" : getRowClass(row),
               ]}
               style={`padding-left: ${1 * row.level}rem; grid-column: ${gridColumn};`}
-              draggable={!row.isGroup}
+              draggable={isRowDraggable(row)}
               data-row-id={row.id}
+              onclick={(e) => handleRowClick(e, row)}
               ondragstart={dragStartHandler}
               ondragend={dragEndHandler}
               ondragenter={dragEnterHandler}

--- a/app/src/components/WorkItemTree.svelte
+++ b/app/src/components/WorkItemTree.svelte
@@ -30,6 +30,7 @@
   import SingleSelectColumnMenu from "./SingleSelectColumnMenu.svelte";
   import IterationColumnMenu from "./IterationColumnMenu.svelte";
   import AddItemDialog from "./AddItemDialog.svelte";
+  import { ghostContextMenuItems } from "$lib/ghostRouting";
 
   dayjs.extend(isBetween);
 
@@ -62,10 +63,36 @@
     addItemDialogOpen = true;
   }
 
+  // Scrolls the row with the given id into the centre of the viewport, used
+  // by the ghost-row context menu's "Jump to primary occurrence" action. If
+  // the row is not currently in the DOM (e.g. an ancestor is collapsed) the
+  // call is a silent no-op aside from a debug log.
+  function jumpToRowById(id: string) {
+    if (typeof document === "undefined") return;
+    const element = document.querySelector<HTMLElement>(
+      `[data-row-id="${CSS.escape(id)}"]`
+    );
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "center" });
+    } else {
+      console.debug(
+        `[WorkItemTree] jumpToRowById: row ${id} not currently in DOM`
+      );
+    }
+  }
+
   function getContextMenuItems(
     node: Node,
     column?: Column<WorkItem>
   ): MenuItem[] {
+    // Ghost rows are reflections of a primary occurrence; they don't support
+    // edits, refresh, filtering, or revert. Show only a "Jump to primary"
+    // action (or a text fallback when no primary is in view) so the menu is
+    // never empty and edit affordances stay hidden.
+    if (node.isGhost) {
+      return ghostContextMenuItems(rows, node.id, jumpToRowById);
+    }
+
     let items: MenuItem[] = [];
 
     function getFilterableField(

--- a/app/src/lib/ghostRouting.test.ts
+++ b/app/src/lib/ghostRouting.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  findPrimaryRow,
+  ghostContextMenuItems,
+  isRowDraggable,
+  type GhostAwareRow,
+} from "./ghostRouting";
+
+type Row = GhostAwareRow;
+
+function row(id: string, opts: Partial<Row> = {}): Row {
+  return { id, isGhost: false, isGroup: false, ...opts };
+}
+
+describe("findPrimaryRow", () => {
+  it("returns the non-ghost row matching `id`", () => {
+    // Ghosts and primaries share the same id (both refer to the same
+    // WorkItemId); the helper must pick the non-ghost occurrence even when
+    // the ghost appears first in the list.
+    const rows: Row[] = [
+      row("a"),
+      row("b", { isGhost: true }),
+      row("b"),
+      row("c"),
+    ];
+    expect(findPrimaryRow(rows, "b")).toEqual(row("b"));
+  });
+
+  it("ignores ghost rows even when their id matches", () => {
+    const rows: Row[] = [row("a"), row("b", { isGhost: true })];
+    expect(findPrimaryRow(rows, "b")).toBeUndefined();
+  });
+
+  it("returns undefined when no row matches the id", () => {
+    const rows: Row[] = [row("a"), row("b")];
+    expect(findPrimaryRow(rows, "missing")).toBeUndefined();
+  });
+});
+
+describe("isRowDraggable", () => {
+  it("is true for a plain non-ghost, non-group row", () => {
+    expect(isRowDraggable(row("a"))).toBe(true);
+  });
+
+  it("is false for a ghost row", () => {
+    expect(isRowDraggable(row("a", { isGhost: true }))).toBe(false);
+  });
+
+  it("is false for a group row", () => {
+    expect(isRowDraggable(row("a", { isGroup: true }))).toBe(false);
+  });
+
+  it("is false for a row that is both ghost and group", () => {
+    expect(
+      isRowDraggable(row("a", { isGhost: true, isGroup: true })),
+    ).toBe(false);
+  });
+});
+
+describe("ghostContextMenuItems", () => {
+  it("returns a single 'Jump to primary occurrence' action when a primary exists", () => {
+    const rows: Row[] = [row("a"), row("b"), row("b", { isGhost: true })];
+    const jumpTo = vi.fn();
+
+    const items = ghostContextMenuItems(rows, "b", jumpTo);
+
+    expect(items).toHaveLength(1);
+    const item = items[0];
+    expect(item.type).toBe("action");
+    if (item.type !== "action") throw new Error("expected action item");
+    expect(item.title).toBe("Jump to primary occurrence");
+
+    item.action();
+    expect(jumpTo).toHaveBeenCalledTimes(1);
+    expect(jumpTo).toHaveBeenCalledWith("b");
+  });
+
+  it("returns a text-only fallback when the ghost has no primary in view", () => {
+    const rows: Row[] = [row("b", { isGhost: true })];
+    const jumpTo = vi.fn();
+
+    const items = ghostContextMenuItems(rows, "b", jumpTo);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].type).toBe("text");
+    expect(jumpTo).not.toHaveBeenCalled();
+  });
+
+  it("never returns an empty list (menu must not render blank)", () => {
+    expect(ghostContextMenuItems([], "missing", vi.fn())).not.toHaveLength(0);
+  });
+});
+

--- a/app/src/lib/ghostRouting.ts
+++ b/app/src/lib/ghostRouting.ts
@@ -1,0 +1,72 @@
+// Pure helpers for ghost-row routing in the tree table. Kept dependency-free
+// so the Svelte component can delegate to them and they can be unit tested
+// without the Tauri/Svelte runtime.
+//
+// A "ghost" row is a reflection of a primary work-item row that has been
+// duplicated into a different position in the tree by the pivoting recipe
+// builder (e.g. to anchor a child under a status group while its real parent
+// lives elsewhere). Ghost rows must look muted, must not be draggable, must
+// not show edit/refresh actions, and clicking them should route the user to
+// the primary occurrence of the same id.
+
+/** Minimal shape a row needs to expose for ghost-routing logic to work. The
+ * generic helpers in this file accept any row that carries an `id` and an
+ * `isGhost` flag; `isGroup` is optional because not every caller exposes it.
+ */
+export type GhostAwareRow = {
+  id: string;
+  isGhost: boolean;
+  isGroup?: boolean;
+};
+
+/** Returns the primary (non-ghost) row whose id matches `id`, or `undefined`
+ * when no such row exists in `rows`. Ghost rows are never returned, even when
+ * their id matches — by definition a ghost is not its own primary. */
+export function findPrimaryRow<T extends GhostAwareRow>(
+  rows: readonly T[],
+  id: string,
+): T | undefined {
+  return rows.find((r) => r.id === id && !r.isGhost);
+}
+
+/** Whether a row should be user-draggable. Ghost rows are reflections and
+ * cannot be re-parented; group rows are structural and aren't draggable
+ * either. */
+export function isRowDraggable(row: GhostAwareRow): boolean {
+  return !row.isGhost && !row.isGroup;
+}
+
+/** Subset of {@link MenuItem} (from `TreeTableContextMenu.svelte`) that the
+ * ghost context-menu builder produces. Declared locally so this module stays
+ * dependency-free; the returned value is assignable to `MenuItem[]`. */
+export type GhostMenuItem =
+  | { type: "action"; title: string; action: () => void }
+  | { type: "text"; title: string };
+
+/** Builds the restricted context-menu shown for ghost rows. When a primary
+ * occurrence is present in `rows`, a single "Jump to primary occurrence"
+ * action is returned that delegates to the supplied {@link jumpTo} callback.
+ * Otherwise a static text item explains why no action is available. The
+ * returned list is always non-empty so the menu never renders blank. */
+export function ghostContextMenuItems<T extends GhostAwareRow>(
+  rows: readonly T[],
+  ghostId: string,
+  jumpTo: (primaryId: string) => void,
+): GhostMenuItem[] {
+  const primary = findPrimaryRow(rows, ghostId);
+  if (primary) {
+    return [
+      {
+        type: "action",
+        title: "Jump to primary occurrence",
+        action: () => jumpTo(primary.id),
+      },
+    ];
+  }
+  return [
+    {
+      type: "text",
+      title: "Ghost row — primary occurrence not in current view",
+    },
+  ];
+}


### PR DESCRIPTION
Closes #66

## Summary

Implements Task 7 of the [pivoting plan](docs/pivoting-implementation-plan.md#task-7-ghost-row-visuals--click-routing): give ghost rows muted styling, suppress their edit / drag affordances, and route clicks on a ghost to the primary occurrence of the same `WorkItemId`.

A "ghost" row is a reflection of a primary work-item that has been duplicated into a different position in the tree by `RecipeNodeBuilder` (e.g. anchoring a child under a Status pivot group while its real parent lives elsewhere). The data already carries `Node.isGhost: bool` end-to-end (Task 2 wired the binding); this PR is the frontend rendering + interaction work.

## Changes

- **`app/src/components/TreeTable.svelte`**
  - `getRowClass` returns `italic text-surface-500-500` for ghost rows (no `hover:bg-...`, so the hover affordance is suppressed). Ghost classification is checked **before** modified/modified-descendent so a ghost always looks ghost-y.
  - `draggable` is now bound to `isRowDraggable(row)` — false for ghost **and** group rows.
  - `dragStartHandler` early-returns + `e.preventDefault()` on ghost rows (defense in depth against a stale browser `draggable` attribute).
  - New `handleRowClick(e, row)` attached as `onclick`: for ghost rows it looks up the primary via `findPrimaryRow(rows, row.id)` and `scrollIntoView({ behavior: "smooth", block: "center" })` on the matching `[data-row-id]` element. Clicks on interactive children (`button, a`) are ignored so the expander chevron and direct-issue link keep their handlers.
- **`app/src/components/WorkItemTree.svelte`**
  - `getContextMenuItems` short-circuits when `node.isGhost`: returns the restricted menu from `ghostContextMenuItems(rows, node.id, jumpToRowById)` — a single "Jump to primary occurrence" action, or a text fallback when no primary is currently in view (so the menu never renders blank).
  - New `jumpToRowById(id)` helper performs the same `scrollIntoView` for the menu path.
- **`app/src/lib/ghostRouting.ts`** (new, dependency-free)
  - `findPrimaryRow(rows, id)` — find the non-ghost row matching `id` (ghost & primary share an id, so this can't be done by id-equality alone).
  - `isRowDraggable(row)` — false for ghost or group.
  - `ghostContextMenuItems(rows, ghostId, jumpTo)` — restricted menu builder.
- **`app/src/lib/ghostRouting.test.ts`** (new, 10 tests) — vitest coverage for every public helper, including the "ghost has no primary in view" no-op path.

Total: 4 files, +241 / -2.

## Design notes

- **Why a pure helper module.** Established repo pattern (`filterableFields.ts` → `WorkItemContext.svelte`, `recipeBarState.ts` → `RecipeBar.svelte`): keep testable logic in pure TS so vitest can cover it without a Svelte runtime.
- **`findPrimaryRow` not `resolveGhostClick`.** An earlier draft of the helper had `resolveGhostClick(rows, clickedRowId)` that tried to look up the clicked row by id, then walk to the primary. That's ambiguous: ghost and primary share an id, so `rows.find(r => r.id === clickedId)` always returns the first occurrence (usually the primary). The test caught this immediately. The component callers already have the actual row object in scope and only need `findPrimaryRow`, so the broken indirection is gone.
- **Skeleton tokens only.** Per spec — `italic text-surface-500-500` matches the example in the plan and the existing `text-surface-700-300` muted-text usage in `RecipeBar.svelte` / `WorkItemStatistics.svelte`. No custom CSS colors.
- **`CSS.escape`.** Used on the primary id in the `[data-row-id="..."]` selector to defend against ids that contain characters with special meaning in CSS selectors (work-item ids are GraphQL global ids, generally safe, but cheap insurance).
- **Pointer-events note** (per `.github/copilot-instructions.md`). No drag handler changes attach `pointermove`/`pointerup` to `document`; the row's existing element-level handlers are reused. The new code only adds an `onclick`.

## Out of scope (follow-ups for Rusty)

- **Auto-expand collapsed ancestors when jumping to a primary.** Currently if the primary is hidden because an ancestor isn't expanded, `scrollIntoView` is a no-op + debug log. The plan acceptance only mentions scroll+select, not expansion, so I deferred it. Worth a follow-up issue.
- **Visual flash on the jumped-to row.** A brief highlight to draw the eye after scroll would be nice; `scrollIntoView` with smooth + center is already a strong cue so I held off rather than introduce per-row selection state.

## Validation (from `E:\prj\ghui-task7`)

| Command | Exit | Notes |
|---|---|---|
| `cargo fmt --all -- --check` | **0** | clean |
| `cargo clippy --all -- -D warnings` | **101** | **2 pre-existing errors only** — `clippy::uninlined_format_args` on `ghui-app/src/telemetry.rs:188` and `ghui-app/src/updater.rs:90`. Neither is in code this PR touches (Rust untouched). CI uses an older Rust toolchain that doesn't lint this and passes. Flagging per spec note. |
| `cargo test --all` | **0** | 64 tests pass in `ghui_lib`, all suites green, ts-rs binding regeneration produces no real diff |
| `cd app && npm run check` | **0** | 0 errors, 0 warnings (svelte-check) |
| `cd app && npm test` | **0** | 32 tests pass (10 new in `ghostRouting.test.ts`) |

## Behaviour walkthrough

With recipe `Pivot(Status) → Hierarchy` (the acceptance recipe from the plan):
- A work-item placed under one Status group appears italicized and muted under the others (its ghost occurrences), with no hover background.
- Right-click on a ghost row shows a single "Jump to primary occurrence" menu item (or "Ghost row — primary occurrence not in current view" if the primary is collapsed/filtered out).
- Left-click on a ghost row smoothly scrolls the primary row to the centre of the viewport.
- Drag attempts on a ghost row do nothing — the `draggable` attribute is false and `dragstart` is suppressed.
- Non-ghost rows are unchanged: same drag-and-drop, same context menu, same hover background, same expander.