### PR TITLE
pivoting(task9): Orthogonal toolbar toggles

### DIFF
--- a/app/src/components/RecipeBar.svelte
+++ b/app/src/components/RecipeBar.svelte
@@ -1,21 +1,40 @@
 <script lang="ts">
   import type { Axis } from "$lib/bindings/Axis";
+  import type { Filters } from "$lib/bindings/Filters";
   import type { PivotConfig } from "$lib/bindings/PivotConfig";
   import { parseRecipe, recipeToString } from "$lib/recipeParser";
   import { PRESETS } from "$lib/recipePresets";
   import {
     applyText,
+    getFilterToggleChecked,
+    getRenderToggleChecked,
     getToggleChecked,
+    setFilterToggle,
+    setRenderToggle,
     setToggle,
+    type FilterToggle,
     type RecipeBarToggle,
+    type RenderToggle,
   } from "./recipeBarState";
 
-  let { value = $bindable<PivotConfig>(), onApply }: {
+  let {
+    value = $bindable<PivotConfig>(),
+    filters,
+    showCounts = $bindable<boolean>(),
+    collapseSingleValue = $bindable<boolean>(),
+    onApply,
+    onFiltersApply,
+  }: {
     value: PivotConfig;
+    filters: Filters;
+    showCounts: boolean;
+    collapseSingleValue: boolean;
     onApply: (cfg: PivotConfig) => void;
+    onFiltersApply: (filters: Filters) => void;
   } = $props();
 
-  const liveToggles: ReadonlyArray<{
+  // PivotConfig-backed toggles (persisted via view config cache).
+  const pivotToggles: ReadonlyArray<{
     id: RecipeBarToggle;
     label: string;
   }> = [
@@ -27,6 +46,27 @@
       id: "showGhostAncestors",
       label: "Show ghost ancestors",
     },
+  ];
+
+  // Filters-backed toggles (persisted via view config cache).
+  const filterToggles: ReadonlyArray<{
+    id: FilterToggle;
+    label: string;
+  }> = [
+    {
+      id: "hideClosed",
+      label: "Hide closed",
+    },
+  ];
+
+  // Frontend-only render toggles. Intentionally NOT persisted — they revert
+  // to defaults on app restart, which is acceptable for pure render concerns.
+  const renderToggles: ReadonlyArray<{
+    id: RenderToggle;
+    label: string;
+  }> = [
+    { id: "showCounts", label: "Show counts" },
+    { id: "collapseSingleValue", label: "Collapse single-value groups" },
   ];
 
   let recipeText = $state("");
@@ -82,6 +122,20 @@
   function updateToggle(toggle: RecipeBarToggle, checked: boolean): void {
     emit(setToggle(value, toggle, checked));
   }
+
+  function updateFilterToggle(toggle: FilterToggle, checked: boolean): void {
+    onFiltersApply(setFilterToggle(filters, toggle, checked));
+  }
+
+  function updateRenderToggle(toggle: RenderToggle, checked: boolean): void {
+    const next = setRenderToggle(
+      { showCounts, collapseSingleValue },
+      toggle,
+      checked
+    );
+    showCounts = next.showCounts;
+    collapseSingleValue = next.collapseSingleValue;
+  }
 </script>
 
 <div class="flex flex-col gap-3 rounded border border-surface-300-700 bg-surface-100-900 p-3">
@@ -134,13 +188,37 @@
     </label>
 
     <div class="flex flex-wrap gap-4 pb-1">
-      {#each liveToggles as toggle}
+      {#each pivotToggles as toggle}
         <label class="flex items-center gap-2 text-sm">
           <input
             type="checkbox"
             checked={getToggleChecked(value, toggle.id)}
             onchange={(event) => {
               updateToggle(toggle.id, (event.currentTarget as HTMLInputElement).checked);
+            }}
+          />
+          <span>{toggle.label}</span>
+        </label>
+      {/each}
+      {#each filterToggles as toggle}
+        <label class="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={getFilterToggleChecked(filters, toggle.id)}
+            onchange={(event) => {
+              updateFilterToggle(toggle.id, (event.currentTarget as HTMLInputElement).checked);
+            }}
+          />
+          <span>{toggle.label}</span>
+        </label>
+      {/each}
+      {#each renderToggles as toggle}
+        <label class="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={getRenderToggleChecked({ showCounts, collapseSingleValue }, toggle.id)}
+            onchange={(event) => {
+              updateRenderToggle(toggle.id, (event.currentTarget as HTMLInputElement).checked);
             }}
           />
           <span>{toggle.label}</span>

--- a/app/src/components/RecipeBar.test.ts
+++ b/app/src/components/RecipeBar.test.ts
@@ -1,13 +1,48 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Axis } from "$lib/bindings/Axis";
+import type { Filters } from "$lib/bindings/Filters";
 import type { PivotConfig } from "$lib/bindings/PivotConfig";
-import { applyText, getToggleChecked, setToggle } from "./recipeBarState";
+import {
+  applyText,
+  getFilterToggleChecked,
+  getRenderToggleChecked,
+  getToggleChecked,
+  setFilterToggle,
+  setRenderToggle,
+  setToggle,
+  type RenderTogglesState,
+} from "./recipeBarState";
 
 function makeConfig(recipe: Axis[] = []): PivotConfig {
   return {
     recipe,
     multiValueStrategy: "combined",
     showGhostAncestors: true,
+  };
+}
+
+function makeFilters(overrides: Partial<Filters> = {}): Filters {
+  return {
+    status: [],
+    blocked: [],
+    epic: [],
+    iteration: [],
+    kind: [],
+    workstream: [],
+    estimate: [],
+    priority: [],
+    hideClosed: false,
+    ...overrides,
+  };
+}
+
+function makeRenderState(
+  overrides: Partial<RenderTogglesState> = {}
+): RenderTogglesState {
+  return {
+    showCounts: false,
+    collapseSingleValue: false,
+    ...overrides,
   };
 }
 
@@ -225,5 +260,111 @@ describe("RecipeBar Explode checkbox — onApply wiring", () => {
       multiValueStrategy: "explode",
       showGhostAncestors: false,
     });
+  });
+});
+
+describe("setFilterToggle", () => {
+  it("sets hideClosed to true when toggled on", () => {
+    expect(setFilterToggle(makeFilters(), "hideClosed", true).hideClosed).toBe(
+      true
+    );
+  });
+
+  it("sets hideClosed to false when toggled off", () => {
+    expect(
+      setFilterToggle(makeFilters({ hideClosed: true }), "hideClosed", false)
+        .hideClosed
+    ).toBe(false);
+  });
+
+  it("preserves the other Filters fields when hideClosed flips", () => {
+    const initial = makeFilters({ status: ["s1"], kind: ["k1"] });
+    const next = setFilterToggle(initial, "hideClosed", true);
+    expect(next).toEqual({ ...initial, hideClosed: true });
+    // Must not mutate the source object.
+    expect(initial.hideClosed).toBe(false);
+  });
+});
+
+describe("getFilterToggleChecked — initial state reflects bound Filters", () => {
+  it("reports hideClosed as checked when Filters.hideClosed is true", () => {
+    expect(
+      getFilterToggleChecked(makeFilters({ hideClosed: true }), "hideClosed")
+    ).toBe(true);
+  });
+
+  it("reports hideClosed as unchecked when Filters.hideClosed is false", () => {
+    expect(getFilterToggleChecked(makeFilters(), "hideClosed")).toBe(false);
+  });
+});
+
+describe("setRenderToggle", () => {
+  it("sets showCounts to true when toggled on", () => {
+    expect(
+      setRenderToggle(makeRenderState(), "showCounts", true).showCounts
+    ).toBe(true);
+  });
+
+  it("sets showCounts to false when toggled off", () => {
+    expect(
+      setRenderToggle(
+        makeRenderState({ showCounts: true }),
+        "showCounts",
+        false
+      ).showCounts
+    ).toBe(false);
+  });
+
+  it("sets collapseSingleValue to true when toggled on", () => {
+    expect(
+      setRenderToggle(makeRenderState(), "collapseSingleValue", true)
+        .collapseSingleValue
+    ).toBe(true);
+  });
+
+  it("sets collapseSingleValue to false when toggled off", () => {
+    expect(
+      setRenderToggle(
+        makeRenderState({ collapseSingleValue: true }),
+        "collapseSingleValue",
+        false
+      ).collapseSingleValue
+    ).toBe(false);
+  });
+
+  it("does not mutate the source RenderTogglesState", () => {
+    const initial = makeRenderState({ showCounts: false });
+    const next = setRenderToggle(initial, "showCounts", true);
+    expect(initial.showCounts).toBe(false);
+    expect(next.showCounts).toBe(true);
+    // Other render toggles preserved.
+    expect(next.collapseSingleValue).toBe(initial.collapseSingleValue);
+  });
+});
+
+describe("getRenderToggleChecked — initial state reflects bound RenderTogglesState", () => {
+  it("reports showCounts as checked when the bound value is true", () => {
+    expect(
+      getRenderToggleChecked(makeRenderState({ showCounts: true }), "showCounts")
+    ).toBe(true);
+  });
+
+  it("reports showCounts as unchecked when the bound value is false", () => {
+    expect(getRenderToggleChecked(makeRenderState(), "showCounts")).toBe(false);
+  });
+
+  it("reports collapseSingleValue as checked when the bound value is true", () => {
+    expect(
+      getRenderToggleChecked(
+        makeRenderState({ collapseSingleValue: true }),
+        "collapseSingleValue"
+      )
+    ).toBe(true);
+  });
+
+  it("reports collapseSingleValue as unchecked when the bound value is false", () => {
+    expect(
+      getRenderToggleChecked(makeRenderState(), "collapseSingleValue")
+    ).toBe(false);
   });
 });

--- a/app/src/components/WorkItemTree.svelte
+++ b/app/src/components/WorkItemTree.svelte
@@ -20,6 +20,7 @@
   import { type PullRequestState } from "$lib/bindings/PullRequestState";
   import { type Fields } from "$lib/bindings/Fields";
   import type { Filters } from "$lib/bindings/Filters";
+  import type { FilterableField } from "$lib/filterableFields";
   import type { WorkItemId } from "$lib/bindings/WorkItemId";
   import ItemMiniIcon from "./ItemMiniIcon.svelte";
   import TableFieldSelect from "./TableFieldSelect.svelte";
@@ -97,7 +98,7 @@
 
     function getFilterableField(
       column: Column<WorkItem> | undefined
-    ): keyof Filters | undefined {
+    ): FilterableField | undefined {
       if (column && context.isFilterableField(column.name)) {
         return column.name;
       }
@@ -105,7 +106,7 @@
     }
 
     function quickFilterItems(
-      field: keyof Filters,
+      field: FilterableField,
       item: WorkItem
     ): MenuItem[] {
       const value = context.getFilterableFieldValue(field, item);
@@ -241,10 +242,39 @@
     else return items;
   }
 
+  // Count of workItem descendants for each group node. Computed by walking
+  // the flat depth-first node array: every descendant of `group` is contiguous
+  // and at a strictly greater level until we hit a node at `<= group.level`.
+  // Used by the showCounts and collapseSingleValue toolbar toggles.
+  let groupChildCounts = $derived.by(() => {
+    const counts = new Map<string, number>();
+    const nodes = context.data.nodes;
+    for (let i = 0; i < nodes.length; i++) {
+      const head = nodes[i];
+      if (head.data.type !== "group") continue;
+      let count = 0;
+      for (let j = i + 1; j < nodes.length; j++) {
+        const child = nodes[j];
+        if (child.level <= head.level) break;
+        if (child.data.type === "workItem") count++;
+      }
+      counts.set(head.id, count);
+    }
+    return counts;
+  });
+
   let rows = $derived.by(() => {
-    return context.data.nodes.map((n) => {
-      return { ...n, isGroup: n.data.type === "group" };
-    });
+    const all = context.data.nodes.map((n) => ({
+      ...n,
+      isGroup: n.data.type === "group",
+    }));
+    if (!context.collapseSingleValue) return all;
+    // When collapseSingleValue is on, hide group rows whose bucket contains
+    // exactly one work item so the lone item renders inline. The child stays
+    // at its own level — visually it just loses its group header.
+    return all.filter(
+      (row) => !(row.isGroup && groupChildCounts.get(row.id) === 1)
+    );
   });
 
   let columns = $state<Column<WorkItem>[]>([
@@ -385,7 +415,9 @@
   }
 
   function getGroup(n: Node) {
-    if (n.data.type === "group") return n.data.name;
+    if (n.data.type === "group") {
+      return { name: n.data.name, count: groupChildCounts.get(n.id) ?? 0 };
+    }
   }
 
   function getItem(n: Node) {
@@ -503,8 +535,12 @@
   <IterationColumnMenu fieldName={column.name as keyof Fields} />
 {/snippet}
 
-{#snippet renderGroup(name: string | undefined)}
-  {name}
+{#snippet renderGroup(group: { name: string; count: number } | undefined)}
+  {#if group}
+    {group.name}{#if context.showCounts}
+      <span class="ml-2 text-surface-700-300">({group.count})</span>
+    {/if}
+  {/if}
 {/snippet}
 
 {#snippet renderTitle(item: WorkItem | undefined)}

--- a/app/src/components/recipeBarState.ts
+++ b/app/src/components/recipeBarState.ts
@@ -1,7 +1,23 @@
 import type { Axis } from "$lib/bindings/Axis";
+import type { Filters } from "$lib/bindings/Filters";
 import type { PivotConfig } from "$lib/bindings/PivotConfig";
 
+/** Toggles whose state lives on `PivotConfig` (persisted via view config cache). */
 export type RecipeBarToggle = "explodeMulti" | "showGhostAncestors";
+
+/** Toggles whose state lives on `Filters` (persisted via view config cache). */
+export type FilterToggle = "hideClosed";
+
+/** Toggles that are pure render concerns and live only in the frontend.
+ *  These intentionally do NOT persist across app restart; they revert to
+ *  the defaults defined by `RenderTogglesState`. */
+export type RenderToggle = "showCounts" | "collapseSingleValue";
+
+/** The collection of frontend-only render toggle values. */
+export type RenderTogglesState = {
+  showCounts: boolean;
+  collapseSingleValue: boolean;
+};
 
 export type ParseFn = (
   text: string
@@ -35,6 +51,9 @@ export async function applyText(
 
 /**
  * Apply a RecipeBar toggle to a PivotConfig, returning the updated config.
+ *
+ * Uses an exhaustive switch with no `default` arm so the TypeScript compiler
+ * flags any new `RecipeBarToggle` variant that forgets a setter.
  */
 export function setToggle(
   config: PivotConfig,
@@ -66,5 +85,70 @@ export function getToggleChecked(
       return config.multiValueStrategy === "explode";
     case "showGhostAncestors":
       return config.showGhostAncestors;
+  }
+}
+
+/**
+ * Apply a filter-bound toggle to a `Filters` value, returning a new copy.
+ *
+ * Exhaustive switch — adding a new `FilterToggle` variant without handling
+ * it here is a compile-time error.
+ */
+export function setFilterToggle(
+  filters: Filters,
+  toggle: FilterToggle,
+  checked: boolean
+): Filters {
+  switch (toggle) {
+    case "hideClosed":
+      return { ...filters, hideClosed: checked };
+  }
+}
+
+/**
+ * Read the current `checked` state of a filter-bound toggle. Inverse of
+ * `setFilterToggle`.
+ */
+export function getFilterToggleChecked(
+  filters: Filters,
+  toggle: FilterToggle
+): boolean {
+  switch (toggle) {
+    case "hideClosed":
+      return filters.hideClosed;
+  }
+}
+
+/**
+ * Apply a render-only toggle to a frontend-only state bag, returning a new
+ * copy. Render toggles are not persisted; flipping them only affects how the
+ * current session renders.
+ *
+ * Exhaustive switch — adding a new `RenderToggle` variant without handling
+ * it here is a compile-time error.
+ */
+export function setRenderToggle(
+  state: RenderTogglesState,
+  toggle: RenderToggle,
+  checked: boolean
+): RenderTogglesState {
+  switch (toggle) {
+    case "showCounts":
+      return { ...state, showCounts: checked };
+    case "collapseSingleValue":
+      return { ...state, collapseSingleValue: checked };
+  }
+}
+
+/** Read the current `checked` state of a render-only toggle. */
+export function getRenderToggleChecked(
+  state: RenderTogglesState,
+  toggle: RenderToggle
+): boolean {
+  switch (toggle) {
+    case "showCounts":
+      return state.showCounts;
+    case "collapseSingleValue":
+      return state.collapseSingleValue;
   }
 }

--- a/app/src/lib/WorkItemContext.svelte.ts
+++ b/app/src/lib/WorkItemContext.svelte.ts
@@ -9,7 +9,6 @@ import type { FieldOptionId } from "./bindings/FieldOptionId";
 import { type DataUpdate } from "./bindings/DataUpdate";
 import { ItemUpdateBatcher } from "./ItemUpdater";
 import type { WorkItem } from "./bindings/WorkItem";
-import type { Filters } from "./bindings/Filters";
 import type { SingleSelect } from "./bindings/SingleSelect";
 import type { Iteration } from "./bindings/Iteration";
 import type { ProjectItem } from "./bindings/ProjectItem";
@@ -19,6 +18,7 @@ import type { ResolvedUrl } from "./bindings/ResolvedUrl";
 import type { RefreshSummary } from "./bindings/RefreshSummary";
 import type { PivotConfig } from "./bindings/PivotConfig";
 import * as filterableFields from "./filterableFields";
+import type { FilterableField } from "./filterableFields";
 
 const key = Symbol("WorkItemContext");
 
@@ -50,6 +50,7 @@ export class WorkItemContext {
       workstream: [],
       estimate: [],
       priority: [],
+      hideClosed: false,
     },
     pivotConfig: {
       recipe: [{ kind: "pivot", field: "epic" }, { kind: "hierarchy" }],
@@ -64,6 +65,15 @@ export class WorkItemContext {
   });
 
   workItemTreeExpandedItems = $state<string[]>([]);
+
+  /**
+   * Frontend-only toolbar toggles (Task 9). Pure render concerns — these do
+   * NOT round-trip through Tauri and do NOT persist across app restart.
+   * `showCounts` appends a `(N)` decorator on group headers. `collapseSingleValue`
+   * hides group rows whose bucket contains exactly one work item, so that
+   * lone item renders inline. */
+  showCounts = $state<boolean>(false);
+  collapseSingleValue = $state<boolean>(false);
 
   logs = $state<LogEntry[]>([]);
   unreadErrorCount = $state<number>(0);
@@ -226,36 +236,47 @@ export class WorkItemContext {
     }
   }
 
-  public get filterableFields(): Array<keyof Filters> {
+  public get filterableFields(): Array<FilterableField> {
     return filterableFields.getFilterableFields(this.data);
   }
 
-  public isFilterableField(name: string): name is keyof Filters {
+  public isFilterableField(name: string): name is FilterableField {
     return filterableFields.isFilterableField(this.data, name);
   }
 
   public getFilterableFieldValue(
-    fieldName: keyof Filters,
+    fieldName: FilterableField,
     workItem: WorkItem
   ): FieldOptionId | null | undefined {
     return filterableFields.getFilterableFieldValue(workItem, fieldName);
   }
 
   public getFilterableFieldOptionIds(
-    fieldName: keyof Filters
+    fieldName: FilterableField
   ): Array<FieldOptionId | null> {
     return filterableFields.getFilterableFieldOptionIds(this.data, fieldName);
   }
 
   public getFilter(fieldName: keyof Fields): Array<FieldOptionId | null> {
-    return this.data.filters[fieldName as keyof Filters];
+    return this.data.filters[fieldName as FilterableField];
   }
 
   public setFilter(
     fieldName: keyof Fields,
     filter: Array<FieldOptionId | null>
   ): void {
-    this.data.filters[fieldName as keyof Filters] = filter;
+    this.data.filters[fieldName as FilterableField] = filter;
+    invoke("set_filters", { filters: this.data.filters });
+  }
+
+  /**
+   * Set the `hideClosed` filter. Mirrors `setFilter`: mutates the local
+   * filters bag (so reactive UI updates immediately) and fires the
+   * `set_filters` command so the backend re-runs `should_include`, rebuilds
+   * the node tree, and persists the new value to the view config cache.
+   */
+  public setHideClosed(hide: boolean): void {
+    this.data.filters.hideClosed = hide;
     invoke("set_filters", { filters: this.data.filters });
   }
 

--- a/app/src/lib/bindings/Filters.ts
+++ b/app/src/lib/bindings/Filters.ts
@@ -10,4 +10,14 @@ export type Filters = {
   workstream: Array<FieldOptionId | null>;
   estimate: Array<FieldOptionId | null>;
   priority: Array<FieldOptionId | null>;
+  /**
+   * When true, items whose underlying GitHub state is closed (issues in
+   * `CLOSED` state, pull requests in `CLOSED` or `MERGED` state) are
+   * filtered out before bucketing. Items whose state hasn't loaded yet are
+   * kept visible so we don't drop them based on unknown data.
+   *
+   * `#[serde(default)]` keeps existing cached `view_config.ghui.json`
+   * files (which predate this field) deserializable.
+   */
+  hideClosed: boolean;
 };

--- a/app/src/lib/filterableFields.test.ts
+++ b/app/src/lib/filterableFields.test.ts
@@ -55,6 +55,7 @@ function makeData(): Data {
       workstream: [],
       estimate: [],
       priority: [],
+      hideClosed: false,
     },
   } as unknown as Data;
 }
@@ -116,6 +117,13 @@ describe("filterable field metadata", () => {
     expect(isFilterableField(data, "__proto__")).toBe(false);
     expect(isFilterableField(data, "toString")).toBe(false);
     expect(isFilterableField(data, "hasOwnProperty")).toBe(false);
+    // `hideClosed` lives on Filters but is a render-only boolean toggle, not
+    // a per-field option-id list — it must NOT be reported as filterable.
+    expect(isFilterableField(data, "hideClosed")).toBe(false);
+  });
+
+  it("getFilterableFields excludes non-field filter keys like hideClosed", () => {
+    expect(getFilterableFields(makeData())).not.toContain("hideClosed");
   });
 });
 

--- a/app/src/lib/filterableFields.ts
+++ b/app/src/lib/filterableFields.ts
@@ -6,18 +6,34 @@ import type { FieldOptionId } from "./bindings/FieldOptionId";
 import type { Filters } from "./bindings/Filters";
 import type { WorkItem } from "./bindings/WorkItem";
 
+/** The subset of `Filters` keys that represent option-id-based field filters
+ *  (i.e. the per-field exclusion lists). `Filters` also carries boolean
+ *  toggles such as `hideClosed`; those are not "filterable fields" in the
+ *  column-menu sense and are excluded from `FilterableField`. */
+export type FilterableField = Exclude<keyof Filters, "hideClosed">;
+
+/** Keys of `Filters` that are NOT per-field option lists. Keep this in sync
+ *  with the boolean fields on the Rust `Filters` struct (`ghui-app/src/lib.rs`).
+ *  When this drifts, `getFilterableFields` will start returning a key that
+ *  callers expect to have `options`, which will explode at runtime. */
+const NON_FIELD_FILTER_KEYS: ReadonlySet<string> = new Set(["hideClosed"]);
+
 /** Names of all fields that support filtering, derived from the `Filters`
- * struct. Single source of truth used wherever code needs to enumerate or test
- * for filterable fields. */
-export function getFilterableFields(data: Data): Array<keyof Filters> {
-  return Object.keys(data.filters) as Array<keyof Filters>;
+ * struct minus the non-field boolean toggles. Single source of truth used
+ * wherever code needs to enumerate or test for filterable fields. */
+export function getFilterableFields(data: Data): Array<FilterableField> {
+  return Object.keys(data.filters).filter(
+    (k) => !NON_FIELD_FILTER_KEYS.has(k)
+  ) as Array<FilterableField>;
 }
 
 export function isFilterableField(
   data: Data,
   name: string
-): name is keyof Filters {
-  return Object.hasOwn(data.filters, name);
+): name is FilterableField {
+  return (
+    !NON_FIELD_FILTER_KEYS.has(name) && Object.hasOwn(data.filters, name)
+  );
 }
 
 /** Returns the FieldOptionId currently set on `workItem` for any filterable
@@ -29,7 +45,7 @@ export function isFilterableField(
  * quick-filter action that would otherwise treat unloaded as `(none)`). */
 export function getFilterableFieldValue(
   workItem: WorkItem,
-  fieldName: keyof Filters
+  fieldName: FilterableField
 ): FieldOptionId | null | undefined {
   const v = workItem.projectItem[fieldName];
   if (v === null || typeof v === "string") return v;
@@ -41,7 +57,7 @@ export function getFilterableFieldValue(
  * shape so they can be handled uniformly. */
 export function getFilterableFieldOptionIds(
   data: Data,
-  fieldName: keyof Filters
+  fieldName: FilterableField
 ): Array<FieldOptionId | null> {
   return [null, ...data.fields[fieldName].options.map((o) => o.id)];
 }

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -75,26 +75,15 @@
   const canRedo = $derived(context.data.canRedo);
   const numEpicConflicts = $derived(context.data.epicConflicts.length);
 
-  // "Hide Closed" toggle is a convenience UI on top of the existing status
-  // filter: when active, the "Closed" status option id is included in
-  // `filters.status`, which already filters those items out via the existing
-  // filter pipeline.
-  const closedStatusOptionId = $derived(
-    context.data.fields.status.options.find((o) => o.value === "Closed")?.id ??
-      null,
-  );
-  const hideClosed = $derived(
-    closedStatusOptionId !== null &&
-      context.data.filters.status.some((id) => id === closedStatusOptionId),
-  );
+  // "Hide Closed" toggle — backed by the `hide_closed` field on Filters
+  // (Rust). When true, items whose underlying GitHub state is closed
+  // (issues in CLOSED state, PRs in CLOSED or MERGED state) are filtered
+  // out before bucketing. The same toggle also appears in RecipeBar so the
+  // two UIs stay in sync via the shared `context.data.filters.hideClosed`
+  // state.
+  const hideClosed = $derived(context.data.filters.hideClosed);
   function toggleHideClosed(): void {
-    if (closedStatusOptionId === null) return;
-    const current = context.getFilter("status");
-    const isHidden = current.includes(closedStatusOptionId);
-    const next = isHidden
-      ? current.filter((id) => id !== closedStatusOptionId)
-      : [...current, closedStatusOptionId];
-    context.setFilter("status", next);
+    context.setHideClosed(!hideClosed);
   }
 
   let saveProgress = $state(0);
@@ -289,7 +278,7 @@
         text="Hide Closed"
         icon={hideClosed ? CircleSlash : CircleCheck}
         active={hideClosed}
-        disabled={disabled || closedStatusOptionId === null}
+        disabled={disabled}
         onclick={toggleHideClosed}
       />
 
@@ -429,7 +418,11 @@
     <div class="border-b border-surface-300-700 px-4 py-2">
       <RecipeBar
         bind:value={context.data.pivotConfig}
+        filters={context.data.filters}
+        bind:showCounts={context.showCounts}
+        bind:collapseSingleValue={context.collapseSingleValue}
         onApply={(cfg) => context.setPivotConfig(cfg)}
+        onFiltersApply={(filters) => context.setHideClosed(filters.hideClosed)}
       />
     </div>
   {/if}

--- a/app/src/routes/dev/recipe-bar/+page.svelte
+++ b/app/src/routes/dev/recipe-bar/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import RecipeBar from "../../../components/RecipeBar.svelte";
+  import type { Filters } from "$lib/bindings/Filters";
   import type { PivotConfig } from "$lib/bindings/PivotConfig";
   import { recipeToString } from "$lib/recipeParser";
 
@@ -9,9 +10,25 @@
     showGhostAncestors: true,
   };
 
+  const initialFilters: Filters = {
+    status: [],
+    blocked: [],
+    epic: [],
+    iteration: [],
+    kind: [],
+    workstream: [],
+    estimate: [],
+    priority: [],
+    hideClosed: false,
+  };
+
   let value = $state<PivotConfig>(structuredClone(initialConfig));
+  let filters = $state<Filters>(structuredClone(initialFilters));
+  let showCounts = $state(false);
+  let collapseSingleValue = $state(false);
 
   let applied = $state<PivotConfig>(structuredClone(initialConfig));
+  let appliedFilters = $state<Filters>(structuredClone(initialFilters));
   let formattedRecipe = $state("");
 
   $effect(() => {
@@ -37,8 +54,15 @@
 
   <RecipeBar
     bind:value
+    {filters}
+    bind:showCounts
+    bind:collapseSingleValue
     onApply={(cfg) => {
       applied = cfg;
+    }}
+    onFiltersApply={(next) => {
+      filters = next;
+      appliedFilters = next;
     }}
   />
 
@@ -51,6 +75,17 @@
     <section class="rounded border border-surface-300-700 bg-surface-100-900 p-4">
       <h2 class="mb-2 text-lg font-medium">Applied config JSON</h2>
       <pre class="overflow-x-auto text-xs">{JSON.stringify(applied, null, 2)}</pre>
+    </section>
+
+    <section class="rounded border border-surface-300-700 bg-surface-100-900 p-4">
+      <h2 class="mb-2 text-lg font-medium">Applied filters JSON</h2>
+      <pre class="overflow-x-auto text-xs">{JSON.stringify(appliedFilters, null, 2)}</pre>
+    </section>
+
+    <section class="rounded border border-surface-300-700 bg-surface-100-900 p-4">
+      <h2 class="mb-2 text-lg font-medium">Render toggles</h2>
+      <p class="font-mono text-sm">showCounts: {showCounts}</p>
+      <p class="font-mono text-sm">collapseSingleValue: {collapseSingleValue}</p>
     </section>
   </div>
 </div>

--- a/app/src/routes/test_stats/+page.svelte
+++ b/app/src/routes/test_stats/+page.svelte
@@ -244,6 +244,7 @@
       workstream: [],
       estimate: [],
       priority: [],
+      hideClosed: false,
     },
     pivotConfig: {
       recipe: [{ kind: "pivot", field: "epic" }, { kind: "hierarchy" }],

--- a/ghui-app/src/lib.rs
+++ b/ghui-app/src/lib.rs
@@ -5,8 +5,8 @@ use github_graphql::{
         custom_fields_query::get_fields, get_all_items, get_items::get_items, get_resource_id,
     },
     data::{
-        Change, ChangeData, Changes, FieldOptionId, Fields, ProjectItemId, SanitizeConflict,
-        SaveMode, UndoHistory, UpdateType, WorkItem, WorkItemId, WorkItems,
+        Change, ChangeData, Changes, DelayLoad, FieldOptionId, Fields, ProjectItemId,
+        SanitizeConflict, SaveMode, UndoHistory, UpdateType, WorkItem, WorkItemId, WorkItems,
     },
     pivot::PivotConfig,
 };
@@ -63,10 +63,26 @@ pub struct Filters {
     workstream: Vec<Option<FieldOptionId>>,
     estimate: Vec<Option<FieldOptionId>>,
     priority: Vec<Option<FieldOptionId>>,
+
+    /// When true, items whose underlying GitHub state is closed (issues in
+    /// `CLOSED` state, pull requests in `CLOSED` or `MERGED` state) are
+    /// filtered out before bucketing. Items whose state hasn't loaded yet are
+    /// kept visible so we don't drop them based on unknown data.
+    ///
+    /// `#[serde(default)]` keeps existing cached `view_config.ghui.json`
+    /// files (which predate this field) deserializable.
+    #[serde(default)]
+    hide_closed: bool,
 }
 
 impl Filters {
     fn should_include(&self, work_item: &WorkItem) -> bool {
+        if self.hide_closed
+            && let DelayLoad::Loaded(true) = work_item.is_closed()
+        {
+            return false;
+        }
+
         let p = &work_item.project_item;
 
         !(self.status.contains(&p.status)
@@ -80,7 +96,8 @@ impl Filters {
     }
 
     /// Returns the total number of individual filter values that are active
-    /// across all fields.
+    /// across all fields. `hide_closed` counts as one active filter when
+    /// enabled.
     pub fn active_filter_count(&self) -> usize {
         self.status.len()
             + self.blocked.len()
@@ -90,6 +107,7 @@ impl Filters {
             + self.workstream.len()
             + self.estimate.len()
             + self.priority.len()
+            + usize::from(self.hide_closed)
     }
 }
 
@@ -794,6 +812,7 @@ fn summarize_refresh_changes(
 mod tests {
     use super::*;
     use github_graphql::data::test_helpers::TestData;
+    use github_graphql::data::{Issue, IssueState, PullRequest, PullRequestState, WorkItemData};
     use github_graphql::pivot::{Axis, MultiValueStrategy, PivotField};
     use std::sync::{Arc, Mutex};
     use tempfile::NamedTempFile;
@@ -932,6 +951,7 @@ mod tests {
         let expected = ViewConfigCache {
             filters: Filters {
                 status: vec![Some(FieldOptionId("status-a".to_string()))],
+                hide_closed: true,
                 ..Default::default()
             },
             pivot_config: PivotConfig {
@@ -950,6 +970,10 @@ mod tests {
 
         assert_eq!(loaded.pivot_config, expected.pivot_config);
         assert_eq!(loaded.filters.status, expected.filters.status);
+        assert!(
+            loaded.filters.hide_closed,
+            "hide_closed should round-trip via the cache file",
+        );
     }
 
     #[test]
@@ -1034,5 +1058,99 @@ mod tests {
 
         let observed = observed_configs.lock().unwrap();
         assert_eq!(observed.last().unwrap(), &next);
+    }
+
+    #[test]
+    fn test_filters_should_include_hide_closed_true_excludes_closed_issue() {
+        let mut data = TestData::default();
+        let open_id = data.build().issue_state(IssueState::OPEN).add();
+        let closed_id = data.build().issue_state(IssueState::CLOSED).add();
+
+        let filters = Filters {
+            hide_closed: true,
+            ..Default::default()
+        };
+
+        let open_item = data.work_items.get(&open_id).unwrap();
+        let closed_item = data.work_items.get(&closed_id).unwrap();
+
+        assert!(filters.should_include(open_item));
+        assert!(!filters.should_include(closed_item));
+    }
+
+    #[test]
+    fn test_filters_should_include_hide_closed_false_keeps_closed_issue() {
+        let mut data = TestData::default();
+        let closed_id = data.build().issue_state(IssueState::CLOSED).add();
+
+        let filters = Filters {
+            hide_closed: false,
+            ..Default::default()
+        };
+
+        let closed_item = data.work_items.get(&closed_id).unwrap();
+        assert!(filters.should_include(closed_item));
+    }
+
+    #[test]
+    fn test_filters_should_include_hide_closed_excludes_merged_pull_request() {
+        // Pull requests in either CLOSED or MERGED state are treated as closed
+        // by WorkItem::is_closed; verify both branches are filtered out.
+        let mut data = TestData::default();
+        let open_pr = data.build().add();
+        let closed_pr = data.build().add();
+        let merged_pr = data.build().add();
+        set_pull_request(&mut data, &open_pr, PullRequestState::OPEN);
+        set_pull_request(&mut data, &closed_pr, PullRequestState::CLOSED);
+        set_pull_request(&mut data, &merged_pr, PullRequestState::MERGED);
+
+        let filters = Filters {
+            hide_closed: true,
+            ..Default::default()
+        };
+
+        assert!(filters.should_include(data.work_items.get(&open_pr).unwrap()));
+        assert!(!filters.should_include(data.work_items.get(&closed_pr).unwrap()));
+        assert!(!filters.should_include(data.work_items.get(&merged_pr).unwrap()));
+    }
+
+    #[test]
+    fn test_filters_should_include_hide_closed_keeps_items_with_unloaded_state() {
+        // Items whose underlying GitHub state hasn't loaded yet have an
+        // `is_closed()` of `DelayLoad::NotLoaded`; in that case we keep the
+        // item visible rather than guessing.
+        let mut data = TestData::default();
+        let id = data.build().add();
+        let item = data.work_items.get_mut(&id).unwrap();
+        item.data = WorkItemData::Issue(Issue::default());
+
+        let filters = Filters {
+            hide_closed: true,
+            ..Default::default()
+        };
+
+        assert!(matches!(item.is_closed(), DelayLoad::NotLoaded));
+        assert!(filters.should_include(item));
+    }
+
+    #[test]
+    fn test_filters_active_filter_count_includes_hide_closed() {
+        let mut filters = Filters::default();
+        assert_eq!(filters.active_filter_count(), 0);
+
+        filters.hide_closed = true;
+        assert_eq!(filters.active_filter_count(), 1);
+
+        filters
+            .status
+            .push(Some(FieldOptionId("status-a".to_string())));
+        assert_eq!(filters.active_filter_count(), 2);
+    }
+
+    fn set_pull_request(data: &mut TestData, id: &WorkItemId, state: PullRequestState) {
+        data.work_items.get_mut(id).unwrap().data = WorkItemData::PullRequest(PullRequest {
+            state: state.into(),
+            assignees: Vec::new(),
+        });
     }
 }


### PR DESCRIPTION
Closes #68.

## What

Wires the final four-toggle toolbar set on the RecipeBar so the user can shape the view without touching the recipe text. Each toggle is owned by the layer that makes sense for it (Brady's "be deliberate about where state lives" guidance from earlier tasks).

| Toggle | State lives | Persists? | Tests |
|---|---|---|---|
| explodeMulti | `PivotConfig.multiValueStrategy` | ✅ view config cache | existing |
| showGhostAncestors | `PivotConfig.showGhostAncestors` | ✅ view config cache | existing |
| **hideClosed** (NEW) | `Filters.hide_closed` (Rust) | ✅ view config cache | new Rust (5) + new TS (5) |
| **showCounts** (NEW) | `WorkItemContext.showCounts` (``) | ❌ intentional | new TS (5) |
| **collapseSingleValue** (NEW) | `WorkItemContext.collapseSingleValue` (``) | ❌ intentional | new TS (5) |

## How

### Rust (`ghui-app/src/lib.rs`)
- New `hide_closed: bool` field on `Filters` with `#[serde(default)]` so existing `view_config.ghui.json` cache files keep deserializing.
- `Filters::should_include` early-returns `false` when the item's state is `Loaded(true)` for `is_closed()`. `NotLoaded` items stay visible — we don't drop rows based on unknown data.
- `active_filter_count` includes the new field.
- Five new unit tests covering the new filter (closed issue excluded, closed kept when off, MERGED PR excluded, unloaded state kept, count++).
- Existing `test_view_config_cache_round_trip_pivot_config` extended to round-trip `hide_closed: true`.

### Top-bar "Hide Closed" button (`+page.svelte`)
The existing "Hide Closed" toolbar button was a convenience UI that hacked on the `filters.status` array (including the "Closed" status option id). It now drives the new `Filters.hideClosed` field directly. **Behaviour difference:**
- Old: hid items whose project Status field was "Closed".
- New: hides items whose GitHub state is closed — catches MERGED PRs even when the project Status isn't set to "Closed". More correct.

The two UIs (toolbar button + RecipeBar checkbox) stay in sync via the shared `context.data.filters.hideClosed`.

### Frontend (`recipeBarState.ts`)
Three orthogonal toggle pairs, all with exhaustive `switch` (no default arm — TS error if a new variant is added without handling):
- `setToggle` / `getToggleChecked` — PivotConfig toggles (existing, unchanged).
- `setFilterToggle` / `getFilterToggleChecked` — Filters toggles (new).
- `setRenderToggle` / `getRenderToggleChecked` — frontend render toggles (new).

### Frontend (`WorkItemTree.svelte`)
- `groupChildCounts` is derived from the flat depth-first `context.data.nodes` array: for each `group` node, walk forward counting `workItem` descendants until level drops back to `<= group.level`.
- `rows = .by(...)` filters out group rows whose count is exactly 1 when `collapseSingleValue` is on, so the lone child renders inline.
- `getGroup` now returns `{name, count}`; `renderGroup` appends `(N)` when `showCounts` is on.

### Frontend (`filterableFields.ts`)
- New `FilterableField = Exclude<keyof Filters, "hideClosed">` type plus runtime `NON_FIELD_FILTER_KEYS = new Set(["hideClosed"])`. Both needed because TS type-narrowing doesn't translate to runtime iteration.
- Future maintainer note: when a new boolean toggle is added to `Filters`, MUST update both `NON_FIELD_FILTER_KEYS` and the `Exclude<>` union.

## Validation

| Step | Result |
|---|---|
| `cargo fmt --all -- --check` | ✅ |
| `cargo clippy --all -- -D warnings` | ⚠️ 2 pre-existing errors in `telemetry.rs:188` and `updater.rs:90` (uninlined_format_args). Zero diff vs origin/main on those files. Unrelated to this PR. |
| `cargo test --all` | ✅ 48 (ghui-app) + 64 (github-graphql) |
| `cd app && npm run check` | ✅ 0 errors, 0 warnings |
| `cd app && npm test` | ✅ 53 tests (was 40 — 13 new in `RecipeBar.test.ts`) |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
