### PR TITLE
Fix column filter menus broken by skeleton-svelte v4

### DIFF
--- a/app/src/components/AddColumnButton.svelte
+++ b/app/src/components/AddColumnButton.svelte
@@ -22,11 +22,6 @@
       <Popover.Content
         class="card bg-surface-100-900 p-4 space-y-4 max-w-[320px]"
       >
-        <Popover.Arrow
-          class="[--arrow-size:8px] [--arrow-background:var(--color-surface-100)] dark:[--arrow-background:var(--color-surface-900)]"
-        >
-          <Popover.ArrowTip />
-        </Popover.Arrow>
         <div class="grid grid-cols-1 gap-2 max-h-[50vh] overflow-y-auto">
           {#each columns as column}
             <button

--- a/app/src/components/AppBarSwitch.svelte
+++ b/app/src/components/AppBarSwitch.svelte
@@ -3,7 +3,7 @@
 
   type Props = { label: string; checked: boolean };
 
-  let { checked = $bindable(), ...props }: Props = $props();
+  let { checked = $bindable(), label }: Props = $props();
 
   function onCheckedChange(details: { checked: boolean }) {
     checked = details.checked;
@@ -12,7 +12,12 @@
 
 <div class="btn flex flex-col p-0.5 mx-1">
   <div class="h-[24px]">
-    <Switch {...props} {onCheckedChange} />
+    <Switch {checked} {onCheckedChange}>
+      <Switch.Control>
+        <Switch.Thumb />
+      </Switch.Control>
+      <Switch.HiddenInput />
+    </Switch>
   </div>
-  <span class="text-xs">{props.label}</span>
+  <span class="text-xs">{label}</span>
 </div>

--- a/app/src/components/SingleSelectColumnMenu.svelte
+++ b/app/src/components/SingleSelectColumnMenu.svelte
@@ -76,12 +76,20 @@
     {#each values as value}
       <div>
         <Switch
+          class="py-1 text-sm text-nowrap"
           checked={value.checked}
           onCheckedChange={({ checked }) => onCheckedChange(value.id, checked)}
         >
-          {value.value}
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+          <Switch.HiddenInput />
+          <Switch.Label>
+            {value.value}
+          </Switch.Label>
         </Switch>
       </div>
     {/each}
   </div>
 </div>
+

--- a/app/src/components/TableColumnMenu.svelte
+++ b/app/src/components/TableColumnMenu.svelte
@@ -30,11 +30,6 @@
   <Portal>
     <Popover.Positioner>
       <Popover.Content class="card bg-surface-100-900 p-4 space-y-4">
-        <Popover.Arrow
-          class="[--arrow-size:8px] [--arrow-background:var(--color-surface-100)] dark:[--arrow-background:var(--color-surface-900)]"
-        >
-          <Popover.ArrowTip />
-        </Popover.Arrow>
         <!-- Render the menu body only while open. skeleton-svelte v4's
              Popover.Content mounts its children eagerly and keeps them mounted,
              so gating on `open` ensures the menu (e.g. the filter list) mounts

--- a/app/src/components/TableColumnMenu.svelte
+++ b/app/src/components/TableColumnMenu.svelte
@@ -18,7 +18,6 @@
   }
 
   let open = $state(false);
-  $effect(() => {});
 </script>
 
 <Popover {open} onOpenChange={(d) => (open = d.open)}>
@@ -36,28 +35,36 @@
         >
           <Popover.ArrowTip />
         </Popover.Arrow>
-        <div class="flex flex-col gap-2">
-          {#if props.onHideColumn}
-            <div
-              class="w-full rounded bg-surface-200-800 p-2 flex justify-center"
-            >
-              <button
-                class="btn btn-sm preset-tonal"
-                onclick={() => {
-                  open = false;
-                  props.onHideColumn?.(props.column);
-                }}
+        <!-- Render the menu body only while open. skeleton-svelte v4's
+             Popover.Content mounts its children eagerly and keeps them mounted,
+             so gating on `open` ensures the menu (e.g. the filter list) mounts
+             fresh each time -- capturing the loaded field options -- and
+             unmounts on close, which is what flushes the staged filter back via
+             the child's unmount effect. -->
+        {#if open}
+          <div class="flex flex-col gap-2">
+            {#if props.onHideColumn}
+              <div
+                class="w-full rounded bg-surface-200-800 p-2 flex justify-center"
               >
-                Hide Column
-              </button>
-            </div>
-          {/if}
-          {#if props.column.renderMenuContent}
-            <div>
-              {@render props.column.renderMenuContent(props.column)}
-            </div>
-          {/if}
-        </div>
+                <button
+                  class="btn btn-sm preset-tonal"
+                  onclick={() => {
+                    open = false;
+                    props.onHideColumn?.(props.column);
+                  }}
+                >
+                  Hide Column
+                </button>
+              </div>
+            {/if}
+            {#if props.column.renderMenuContent}
+              <div>
+                {@render props.column.renderMenuContent(props.column)}
+              </div>
+            {/if}
+          </div>
+        {/if}
       </Popover.Content>
     </Popover.Positioner>
   </Portal>

--- a/app/src/components/switchAnatomy.test.ts
+++ b/app/src/components/switchAnatomy.test.ts
@@ -19,7 +19,15 @@ const sources = import.meta.glob("../**/*.svelte", {
 function stripComments(source: string): string {
   // Drop HTML/Svelte comments so commented-out markup can't create false
   // matches in either direction.
-  return source.replace(/<!--[\s\S]*?-->/g, "");
+  // Apply repeatedly to avoid incomplete multi-character sanitization where
+  // comment delimiters can reappear after a single replacement pass.
+  let current = source;
+  let previous: string;
+  do {
+    previous = current;
+    current = current.replace(/<!--[\s\S]*?-->/g, "");
+  } while (current !== previous);
+  return current;
 }
 
 function countMatches(source: string, re: RegExp): number {

--- a/app/src/components/switchAnatomy.test.ts
+++ b/app/src/components/switchAnatomy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+// Guards against the skeleton-svelte v4 migration regression where some
+// components were left using the removed monolithic `<Switch>...{label}...</Switch>`
+// API. In v4 a bare `<Switch>` (the Root) renders only an empty `<label>` with no
+// visible control, which is what broke the single-select column filter menus
+// (Kind/Status/Workstream/etc.) — the toggles disappeared and the filter list
+// looked empty. Every Skeleton `Switch` must use the compound anatomy
+// (`Switch.Control` + `Switch.Thumb` + `Switch.HiddenInput`).
+
+// Read every component's source as a raw string via Vite (no node:fs needed, so
+// this stays within the repo's "plain TS, runs in Node" test convention).
+const sources = import.meta.glob("../**/*.svelte", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+function stripComments(source: string): string {
+  // Drop HTML/Svelte comments so commented-out markup can't create false
+  // matches in either direction.
+  return source.replace(/<!--[\s\S]*?-->/g, "");
+}
+
+function countMatches(source: string, re: RegExp): number {
+  return (source.match(re) ?? []).length;
+}
+
+const importsSkeletonSwitch = (source: string): boolean =>
+  /import\s*\{[^}]*\bSwitch\b[^}]*\}\s*from\s*["']@skeletonlabs\/skeleton-svelte["']/.test(
+    source
+  );
+
+// Root `<Switch` but not `<Switch.Foo` subcomponents.
+const ROOT_SWITCH = /<Switch(?=[\s>])/g;
+const CONTROL = /<Switch\.Control(?=[\s>])/g;
+const THUMB = /<Switch\.Thumb(?=[\s/>])/g;
+const HIDDEN_INPUT = /<Switch\.HiddenInput(?=[\s/>])/g;
+
+describe("Skeleton Switch usages use the compound anatomy", () => {
+  const files = Object.entries(sources).filter(([, source]) =>
+    importsSkeletonSwitch(source)
+  );
+
+  it("finds the components that use Switch", () => {
+    // Sanity check so this suite can never silently pass by scanning nothing.
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const [path, raw] of files) {
+    it(`${path} renders a control/thumb/hidden-input for every root Switch`, () => {
+      const source = stripComments(raw);
+      const roots = countMatches(source, ROOT_SWITCH);
+      expect(roots).toBeGreaterThan(0);
+      expect(countMatches(source, CONTROL)).toBeGreaterThanOrEqual(roots);
+      expect(countMatches(source, THUMB)).toBeGreaterThanOrEqual(roots);
+      expect(countMatches(source, HIDDEN_INPUT)).toBeGreaterThanOrEqual(roots);
+    });
+  }
+});

--- a/app/src/components/tableColumnMenuMount.test.ts
+++ b/app/src/components/tableColumnMenuMount.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+// Guards against the skeleton-svelte v4 regression where the column header menu
+// rendered its body eagerly. Popover.Content in v4 mounts (and keeps mounted)
+// its children regardless of open state, so the filter menu used to:
+//   * freeze an empty option list (it `untrack`s field.options at mount, before
+//     the project fields have loaded), and
+//   * never flush staged filter changes (the child flushes on unmount, which
+//     never happened while the menu stayed mounted).
+// TableColumnMenu must therefore only render the menu body while `open`, so the
+// menu mounts fresh on open and unmounts (flushing) on close.
+
+const sources = import.meta.glob("./TableColumnMenu.svelte", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+describe("TableColumnMenu only mounts its menu body while open", () => {
+  const source = Object.values(sources)[0];
+
+  it("loads the component source", () => {
+    expect(source).toBeTruthy();
+  });
+
+  it("gates renderMenuContent behind an {#if open} block", () => {
+    const gateIndex = source.indexOf("{#if open}");
+    const renderIndex = source.indexOf(
+      "props.column.renderMenuContent(props.column)"
+    );
+    expect(gateIndex).toBeGreaterThanOrEqual(0);
+    expect(renderIndex).toBeGreaterThanOrEqual(0);
+    // The menu body (which includes the renderMenuContent call) must live
+    // inside the `{#if open}` gate so it mounts/unmounts with the popover.
+    expect(gateIndex).toBeLessThan(renderIndex);
+  });
+});

--- a/app/src/components/tableColumnMenuMount.test.ts
+++ b/app/src/components/tableColumnMenuMount.test.ts
@@ -34,4 +34,12 @@ describe("TableColumnMenu only mounts its menu body while open", () => {
     // inside the `{#if open}` gate so it mounts/unmounts with the popover.
     expect(gateIndex).toBeLessThan(renderIndex);
   });
+
+  it("does not render a Popover.Arrow (it rendered as a stray dark diamond)", () => {
+    // The skeleton-svelte v4 migration placed Popover.Arrow/ArrowTip inside
+    // Popover.Content, which rendered as a detached black diamond near the
+    // column header. The arrow is purely decorative and was removed.
+    expect(source).not.toMatch(/<Popover\.Arrow[\s>]/);
+    expect(source).not.toMatch(/<Popover\.ArrowTip[\s/>]/);
+  });
 });


### PR DESCRIPTION
## Summary

The column **filter menus** were broken by the recent `@skeletonlabs/skeleton-svelte` v4 migration (#126). Opening a single-select column menu (Kind, Workstream, Status, etc.) showed broken/empty toggles, an empty value list, and a stray black diamond. This PR restores them. There were three distinct root causes:

1. **Switch API change** — v4 made `Switch` a compound component, but the migration only updated `IterationColumnMenu`. `SingleSelectColumnMenu` (and the unused `AppBarSwitch`) still used the removed monolithic `<Switch>{label}</Switch>` form, which renders only an empty `<label>` with no control. Migrated them to the `Switch.Control`/`Switch.Thumb`/`Switch.HiddenInput`(/`Switch.Label`) anatomy.

2. **Popover eager-mounting** — v4's `Popover.Content` mounts its children eagerly and keeps them mounted. The menu was written for mount-on-open: it `untrack`s `field.options` at mount (which now happens before fields load → empty list), and flushes staged filters from its unmount effect (which never ran → filters didn't apply). Fixed by gating the menu body behind `{#if open}` so it mounts fresh on open and unmounts (flushing) on close.

3. **Broken Popover arrow** — the migration nested `Popover.Arrow`/`Popover.ArrowTip` inside `Popover.Content`, rendering a detached dark diamond near the column header. Removed the decorative arrow from `TableColumnMenu` and `AddColumnButton`.

## Tests

Added two pure-TS vitest guards (no new tooling), consistent with the repo's plain-TS frontend test convention:
- `switchAnatomy.test.ts` — asserts every Skeleton `Switch` usage includes the required compound anatomy.
- `tableColumnMenuMount.test.ts` — asserts the menu body is gated behind `{#if open}` and that no broken `Popover.Arrow` is reintroduced.

Both guards were verified to fail on the pre-fix code.

## Validation

- ✅ `cd app && npm run check` — 0 errors, 0 warnings
- ✅ `cd app && npm test` — 86 passed

(No Rust changed, so the Rust checks are unaffected.)
