### PR TITLE
Use GITHUB_TOKEN for release workflow instead of RELEASE_PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-      with:
-        # Need a PAT to push back to main (bypasses rulesets)
-        token: ${{ secrets.RELEASE_PAT }}
+      # Uses the default GITHUB_TOKEN; the GitHub Actions app is a ruleset
+      # bypass actor so the version-bump commit can be pushed to main.
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

The Release workflow was failing at the `actions/checkout` step because it authenticated with `secrets.RELEASE_PAT`, which is no longer valid (the project has moved off stored PATs, see #168). Other workflows pass with the same `checkout@v7` using the default `GITHUB_TOKEN`, confirming the version bump in #164 is not the cause.

In addition, the `standard` branch ruleset no longer has an admin bypass actor, so the workflow's version-bump commit could not be pushed to main even with a valid token.

## Changes

- `release.yml` now uses the default `GITHUB_TOKEN` (checkout persists it for the push) instead of `RELEASE_PAT`.
- The GitHub Actions app is being added as a `bypass_mode: always` bypass actor on the `standard` ruleset (repo setting) so the GITHUB_TOKEN-authored version-bump commit can be pushed to main.

Assisted-by: copilot