### PR TITLE
Suppress console window for gh CLI calls on Windows

### DIFF
--- a/github-graphql/src/client/transport.rs
+++ b/github-graphql/src/client/transport.rs
@@ -113,6 +113,7 @@ impl GhRunner for RealGhRunner {
             // Don't flash a console window for each gh call on Windows.
             #[cfg(windows)]
             {
+                use std::os::windows::process::CommandExt;
                 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
                 command.creation_flags(CREATE_NO_WINDOW);
             }

--- a/github-graphql/src/client/transport.rs
+++ b/github-graphql/src/client/transport.rs
@@ -103,12 +103,21 @@ impl GhRunner for RealGhRunner {
             use tokio::io::AsyncWriteExt;
             use tokio::process::Command;
 
-            let mut child = Command::new("gh")
+            let mut command = Command::new("gh");
+            command
                 .args(["api", "graphql", "--input", "-"])
                 .stdin(std::process::Stdio::piped())
                 .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .spawn()?;
+                .stderr(std::process::Stdio::piped());
+
+            // Don't flash a console window for each gh call on Windows.
+            #[cfg(windows)]
+            {
+                const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+                command.creation_flags(CREATE_NO_WINDOW);
+            }
+
+            let mut child = command.spawn()?;
 
             if let Some(mut stdin) = child.stdin.take() {
                 stdin.write_all(&input).await?;

--- a/github-graphql/src/client/transport.rs
+++ b/github-graphql/src/client/transport.rs
@@ -113,7 +113,6 @@ impl GhRunner for RealGhRunner {
             // Don't flash a console window for each gh call on Windows.
             #[cfg(windows)]
             {
-                use std::os::windows::process::CommandExt;
                 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
                 command.creation_flags(CREATE_NO_WINDOW);
             }


### PR DESCRIPTION
## Summary

After #168 every GraphQL request shells out to `gh api graphql` via `GhCliClient`. On Windows each spawn flashed a console window, so running the app produced a window pop-up for every `gh` invocation.

## Fix

Pass `CREATE_NO_WINDOW` (`0x08000000`) to the `gh` process when spawning it on Windows. All `gh` calls (GraphQL transport and the auth-status check) funnel through `RealGhRunner`, so this single spot covers them.

## Validation

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --all -- -D warnings`
- ✅ `cargo test -p github-graphql`
- ✅ `cd app && npm run check`
- ✅ `cd app && npm test`

Assisted-by: copilot