### PR TITLE
Fix dompurify vulnerability (Dependabot #66); dismiss Linux-only glib alert (#1)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2250,9 +2250,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/app/package.json
+++ b/app/package.json
@@ -51,6 +51,6 @@
   },
   "overrides": {
     "cookie": "^0.7.0",
-    "dompurify": "^3.4.11"
+    "dompurify": "^3.4.12"
   }
 }


### PR DESCRIPTION
## Summary

Addresses the two open Dependabot alerts on this repo.

### #66 dompurify (npm, LOW) — FIXED
`dompurify <= 3.4.11` has a `CUSTOM_ELEMENT_HANDLING` hook-policy inconsistency (GHSA-c2j3-45gr-mqc4, second-order XSS gadget), patched in `3.4.12`. dompurify is a **transitive** dependency via `monaco-editor`. This PR bumps the existing npm `overrides` entry from `^3.4.11` to `^3.4.12` and updates the lockfile (surgical, dompurify-only change).

### #1 glib (rust, MEDIUM) — DISMISSED (no code change)
`glib 0.18.5` (RUSTSEC-2024-0429, a NULL-deref soundness crash — not RCE) comes from the **Linux** GTK/WebKit backend (`gdk`/`gtk` 0.18 via `tao`/`wry`/`tauri`, cfg-gated). ghui ships as a **Windows** desktop app (MSI/NSIS), so this code path is never exercised on the shipped target. There is **no upstream fix path**: the latest `wry` (0.55.1, already in use) still requires the gtk-rs 0.18 stack, which pins `glib ^0.18`, so `glib 0.20` cannot be forced. The alert has been dismissed as `tolerable_risk`; revisit when tauri/wry move to gtk-rs 0.20.

## Validation

| Check | Result |
|-------|--------|
| `npm ci` (lockfile in sync) | ✅ |
| `npm run build` | ✅ |
| `npm run check` | ✅ 0 errors / 0 warnings |
| `npm test` | ✅ 90 passed |

Resolved `dompurify` version confirmed `3.4.12` (integrity verified against the tarball sha1). No Rust/`Cargo.*` changes.
